### PR TITLE
Update the PDA sharing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -875,7 +875,7 @@ pub struct WithdrawTokens<'info> {
         seeds = [b"pool", withdraw_destination.key().as_ref()],
         bump = pool.bump,                                        
     )]
-    pool: Account<'info, TokenPool>,
+    pool: Account<'info, TokenPool>, // Authority for the vault
     #[account(mut)]
     vault: Account<'info, TokenAccount>,
     #[account(mut)]

--- a/README.md
+++ b/README.md
@@ -823,11 +823,13 @@ pub mod pda_sharing_insecure {
 
 #[derive(Accounts)]
 pub struct WithdrawTokens<'info> {
-    #[account(has_one = vault, has_one = withdraw_destination)]
+    #[account(
+        seeds = [b"pool", pool.mint.as_ref()],
+        bump = pool.bump,                                        
+    )]
     pool: Account<'info, TokenPool>,
     vault: Account<'info, TokenAccount>,
     withdraw_destination: Account<'info, TokenAccount>,
-    authority: Signer<'info>,
     token_program: Program<'info, Token>,
 }
 
@@ -837,7 +839,7 @@ impl<'info> WithdrawTokens<'info> {
         let accounts = token::Transfer {
             from: self.vault.to_account_info(),
             to: self.withdraw_destination.to_account_info(),
-            authority: self.authority.to_account_info(),
+            authority: self.pool.to_account_info(),
         };
         CpiContext::new(program, accounts)
     }
@@ -845,9 +847,7 @@ impl<'info> WithdrawTokens<'info> {
 
 #[account]
 pub struct TokenPool {
-    vault: Pubkey,
     mint: Pubkey,
-    withdraw_destination: Pubkey,
     bump: u8,
 }
 ```
@@ -869,11 +869,17 @@ pub mod pda_sharing_secure {
 
 #[derive(Accounts)]
 pub struct WithdrawTokens<'info> {
-    #[account(has_one = vault, has_one = withdraw_destination)]
+    #[account(
+        has_one = vault,
+        has_one = withdraw_destination,
+        seeds = [b"pool", withdraw_destination.key().as_ref()],
+        bump = pool.bump,                                        
+    )]
     pool: Account<'info, TokenPool>,
+    #[account(mut)]
     vault: Account<'info, TokenAccount>,
+    #[account(mut)]
     withdraw_destination: Account<'info, TokenAccount>,
-    authority: Signer<'info>,
     token_program: Program<'info, Token>,
 }
 
@@ -883,7 +889,7 @@ impl<'info> WithdrawTokens<'info> {
         let accounts = token::Transfer {
             from: self.vault.to_account_info(),
             to: self.withdraw_destination.to_account_info(),
-            authority: self.authority.to_account_info(),
+            authority: self.pool.to_account_info(),
         };
         CpiContext::new(program, accounts)
     }
@@ -892,7 +898,6 @@ impl<'info> WithdrawTokens<'info> {
 #[account]
 pub struct TokenPool {
     vault: Pubkey,
-    mint: Pubkey,
     withdraw_destination: Pubkey,
     bump: u8,
 }


### PR DESCRIPTION
The has_one constraint makes an attack not possible, the reason is that if we assume that when the vault is created the program ensures that the vault did not previously exist and that the vault and destination were controlled by the same user then it goes on to create the pool, the existence of the pool(only programs can create their own PDAs) would guarantee that the vault/destination pair is valid If at all the assumption did not hold, then the problem would be from the creation instruction and not with pda sharing, because it not enforcing that would leave no way of matching users their own vaults since any user can create a withdrawal address for any vault. The authority account is removed because it's not really used for anything, it is also used as a signer in the accounts struct and in the instruction it also signs, this would only work in a self-cpi, which i assume is out of context here and is a mistake.